### PR TITLE
fix table 2 week number definitions

### DIFF
--- a/srfi-19.html
+++ b/srfi-19.html
@@ -497,11 +497,11 @@ converters; implementations are free to extend this list.
 <TR><TD width="5%"><code>~t</code></TD><TD WIDTH="95%">horizontal tab</TD></TR>
 <TR><TD width="5%"><code>~T</code></TD><TD WIDTH="95%">time, 24 hour clock, same as "~H:~M:~S"</TD></TR>
 <TR><TD width="5%"><code>~U</code></TD><TD WIDTH="95%">week  number  of  year  with Sunday as first day of week (00...53)</TD></TR>
-<TR><TD width="5%"><code>~V</code></TD><TD WIDTH="95%">week number of year with Monday  as  first  day  of week (01...52)</TD></TR>
+<TR><TD width="5%"><code>~V</code></TD><TD WIDTH="95%">ISO 8601 week number of the year with Monday as first day of week (01..53)</TD></TR>
 <TR><TD width="5%"><code>~w</code></TD><TD WIDTH="95%"> day of week (0...6)</TD></TR>
 <TR><TD width="5%"><code>~W</code></TD><TD WIDTH="95%">week  number  of  year  with Monday as first day of week (01...52)</TD></TR>
-<TR><TD width="5%"><code>~x</code></TD><TD WIDTH="95%">week  number  of  year  with Monday as first day of week (00...53)</TD></TR>
-<TR><TD width="5%"><code>~X</code></TD><TD WIDTH="95%">locale's date representation, for example: "07/31/00" </TD></TR>
+<TR><TD width="5%"><code>~x</code></TD><TD WIDTH="95%">locale's date representation</TD></TR>
+<TR><TD width="5%"><code>~X</code></TD><TD WIDTH="95%">locale's time representation</TD></TR>
 <TR><TD width="5%"><code>~y</code></TD><TD WIDTH="95%">last two digits of year (00...99)</TD></TR>
 <TR><TD width="5%"><code>~Y</code></TD><TD WIDTH="95%">year</TD></TR>
 <TR><TD width="5%"><code>~z</code></TD><TD WIDTH="95%">time zone in RFC-822 style</TD></TR>


### PR DESCRIPTION
This fixes some definitions in Table 2 to be in line with strftime(), and the implementation as  [discussed](https://srfi-email.schemers.org/srfi-19/msg/10875627) in the mailing list.