### PR TITLE
Improvements/clarify and fix k and l directives

### DIFF
--- a/srfi-19-test-suite.scm
+++ b/srfi-19-test-suite.scm
@@ -209,8 +209,8 @@
   (lambda ()
     (let ((d (make-date 0 1 2 3 4 5 2006 0)))
       (and
-       (string=? "3" (date->string d "~k"))
-       (string=? "3" (date->string d "~l"))))
+       (string=? " 3" (date->string d "~k"))
+       (string=? " 3" (date->string d "~l"))))
     ))
 
 (begin (newline) (run-s19-tests #t))

--- a/srfi-19-test-suite.scm
+++ b/srfi-19-test-suite.scm
@@ -205,6 +205,14 @@
        (time=? ct-utc (date->time-utc cd))
        (time=? ct-tai (date->time-tai cd))))))
 
+(define-s19-test! "date->string"
+  (lambda ()
+    (let ((d (make-date 0 1 2 3 4 5 2006 0)))
+      (and
+       (string=? "3" (date->string d "~k"))
+       (string=? "3" (date->string d "~l"))))
+    ))
+
 (begin (newline) (run-s19-tests #t))
 
 

--- a/srfi-19.html
+++ b/srfi-19.html
@@ -480,8 +480,8 @@ converters; implementations are free to extend this list.
 <TR><TD width="5%"><code>~H</code></TD><TD WIDTH="95%">hour, zero padded, 24-hour clock (00...23)</TD></TR>
 <TR><TD width="5%"><code>~I</code></TD><TD WIDTH="95%">hour, zero padded, 12-hour clock (01...12)</TD></TR>
 <TR><TD width="5%"><code>~j</code></TD><TD WIDTH="95%">day of year, zero padded</TD></TR>
-<TR><TD width="5%"><code>~k</code></TD><TD WIDTH="95%">hour, blank padded, 24-hour clock (00...23)</TD></TR>
-<TR><TD width="5%"><code>~l</code></TD><TD WIDTH="95%">hour, blank padded, 12-hour clock (01...12)</TD></TR>
+<TR><TD width="5%"><code>~k</code></TD><TD WIDTH="95%">hour, blank padded, 24-hour clock ( 0...23)</TD></TR>
+<TR><TD width="5%"><code>~l</code></TD><TD WIDTH="95%">hour, blank padded, 12-hour clock ( 1...12)</TD></TR>
 <TR><TD width="5%"><code>~m</code></TD><TD WIDTH="95%">month, zero padded (01...12)</TD></TR>
 <TR><TD width="5%"><code>~M</code></TD><TD WIDTH="95%">minute, zero padded (00...59)</TD></TR>
 <TR><TD width="5%"><code>~n</code></TD><TD WIDTH="95%">new line</TD></TR>

--- a/srfi-19.scm
+++ b/srfi-19.scm
@@ -1054,7 +1054,7 @@
 			port)))
    (cons #\k (lambda (date pad-with port)
 	       (display (tm:padding (date-hour date)
-				    #\0 2)
+				    #\space 2)
                         port)))
    (cons #\l (lambda (date pad-with port)
 	       (let ((hr (if (> (date-hour date) 12)


### PR DESCRIPTION
- Fixing description of `~k` and `~l` directives
- Fixing implementation of `~k` directive
- Adding test for `date->string`