### PR TITLE
Using ~H for directives from ~2 to ~5

### DIFF
--- a/srfi-19-test-suite.scm
+++ b/srfi-19-test-suite.scm
@@ -210,7 +210,11 @@
     (let ((d (make-date 0 1 2 3 4 5 2006 0)))
       (and
        (string=? " 3" (date->string d "~k"))
-       (string=? " 3" (date->string d "~l"))))
+       (string=? " 3" (date->string d "~l"))
+       (string=? "2006-05-04T03:02:01" (date->string d "~5"))
+       (string=? "2006-05-04T03:02:01Z" (date->string d "~4"))
+       (string=? "03:02:01" (date->string d "~3"))
+       (string=? "03:02:01Z" (date->string d "~2"))))
     ))
 
 (begin (newline) (run-s19-tests #t))

--- a/srfi-19.scm
+++ b/srfi-19.scm
@@ -1133,13 +1133,13 @@
    (cons #\1 (lambda (date pad-with port)
 	       (display (date->string date "~Y-~m-~d") port)))
    (cons #\2 (lambda (date pad-with port)
-	       (display (date->string date "~k:~M:~S~z") port)))
+	       (display (date->string date "~H:~M:~S~z") port)))
    (cons #\3 (lambda (date pad-with port)
-	       (display (date->string date "~k:~M:~S") port)))
+	       (display (date->string date "~H:~M:~S") port)))
    (cons #\4 (lambda (date pad-with port)
-	       (display (date->string date "~Y-~m-~dT~k:~M:~S~z") port)))
+	       (display (date->string date "~Y-~m-~dT~H:~M:~S~z") port)))
    (cons #\5 (lambda (date pad-with port)
-	       (display (date->string date "~Y-~m-~dT~k:~M:~S") port)))
+	       (display (date->string date "~Y-~m-~dT~H:~M:~S") port)))
    ))
 
 


### PR DESCRIPTION
The ISO date format directives must also use ~H instead of ~k