### PR TITLE
Reflect 2019-6-11 errata to the reference implementation

### DIFF
--- a/srfi-19-gauche.scm
+++ b/srfi-19-gauche.scm
@@ -1,0 +1,72 @@
+;;
+;; Adapter to load srfi-19.scm into Gacuhe
+;;
+;; To run the test suite:
+;;   $ gosh -I. -usrfi-19-gauche ./srfi-19-test-suite.scm
+;;
+;; You'll see warnings on redefining setters, since the reference implementation
+;; mimics immutable fields by clobbering setters.  You can ignore them.
+;;
+(define-module srfi-19-gauche
+  (use gauche.record)
+  (use util.match)
+  (export time-tai time-utc time-monotonic time-thread
+          time-process time-duration current-time time-resolution
+          make-time time? time-type time-second time-nanosecond
+          set-time-type! set-time-second! set-time-nanosecond! copy-time
+          time=? time<? time<=? time>? time>=?
+          time-difference time-difference! add-duration add-duration!
+          subtract-duration subtract-duration!
+          make-date date? date-nanosecond date-second date-minute
+          date-hour date-day date-month date-year date-zone-offset
+          date-year-day date-week-day date-week-number current-date
+          current-julian-day current-modified-julian-day
+          date->julian-day date->modified-julian-day date->time-monotonic
+          date->time-tai date->time-utc
+          julian-day->date julian-day->time-monotonic
+          julian-day->time-tai julian-day->time-utc
+          modified-julian-day->date modified-julian-day->time-monotonic
+          modified-julian-day->time-tai modified-julian-day->time-utc
+          time-monotonic->date time-monotonic->julian-day
+          time-monotonic->modified-julian-day
+          time-monotonic->time-tai time-monotonic->time-tai!
+          time-monotonic->time-utc time-monotonic->time-utc!
+          time-utc->date time-utc->julian-day
+          time-utc->modified-julian-day
+          time-utc->time-monotonic time-utc->time-monotonic!
+          time-utc->time-tai time-utc->time-tai!
+          time-tai->date time-tai->julian-day
+          time-tai->modified-julian-day
+          time-tai->time-monotonic time-tai->time-monotonic!
+          time-tai->time-utc time-tai->time-utc!
+          date->string string->date))
+(select-module srfi-19-gauche)
+
+;; Translate define-struct to defne-record.
+(define-syntax define-struct
+  (er-macro-transformer
+   (^[f r c]
+     (match f
+       [(_ name (fields ...) (_))
+        (let ((field-specs (map (^[field]
+                                  `(,field
+                                    ,(symbol-append name '- field)
+                                    ,(symbol-append 'set- name '- field '!)))
+                                fields)))
+          (quasirename r
+            `(define-record-type ,name
+               ,(symbol-append 'make- name)
+               ,(symbol-append name '?)
+               ,@field-specs)))]))))
+
+(define (current-seconds) (values-ref (sys-gettimeofday) 0))
+(define (current-milliseconds) (values-ref (sys-gettimeofday) 1))
+
+(define (current-process-milliseconds)
+  (let* ([times (sys-times)]
+         [cpu   (+ (car times) (cadr times))]
+         [tick  (list-ref times 4)])
+    (* cpu (/ 1e6 tick))))
+(define (current-gc-milliseconds) 0) ; used in srfi-19.scm, but not in spec
+
+(include "srfi-19")

--- a/srfi-19-test-suite.scm
+++ b/srfi-19-test-suite.scm
@@ -217,6 +217,46 @@
        (string=? "03:02:01Z" (date->string d "~2"))))
     ))
 
+(let ((dates '((2020 12 31 . "53") ; Thursday, week 53
+               (2021 1 1   . "53") ; Friday, week 53 (previous year)
+               (2021 1 3   . "53") ; Sunday, week 53 (previous year)
+               (2021 1 4   . "01") ; Monday, week 1
+
+               (2019 12 29 . "52") ; Sunday, week 52
+               (2019 12 30 . "01") ; Monday, week 1 (next year)
+               (2019 12 31 . "01") ; Tuesday, week 1 (next year)
+               (2020 1 1   . "01") ; Wednesday, week 1
+
+               (2016 12 31 . "52") ; Saturday, week 52
+               (2017 1 1   . "52") ; Sunday, week 52 (previous year)
+               (2017 1 2   . "01") ; Monday, week 1
+               (2017 1 8   . "01") ; Sunday, week 1
+               (2017 1 9   . "02") ; Monday, week 2
+
+               (2014 12 28 . "52") ; Sunday, week 52
+               (2014 12 29 . "01") ; Monday, week 1 (next year)
+               (2014 12 30 . "01") ; Tuesday, week 1 (next year)
+               (2014 12 31 . "01") ; Wednesday, week 1 (next year)
+               (2015 1 1   . "01") ; Thursday, week 1
+               (2015 1 2   . "01") ; Friday, week 1
+               (2015 1 3   . "01") ; Saturday, week 1
+               (2015 1 4   . "01") ; Sunday, week 1
+               (2015 1 5   . "02") ; Monday, week 2
+               )))
+  (for-each
+   (lambda (date)
+     (let ((p (open-output-string)))
+       (display "date->string ~V " p)
+       (write date p)
+       (define-s19-test! (get-output-string p)
+         (lambda ()
+           (equal? (date->string (make-date 0 0 0 0
+                                            (caddr date) (cadr date) (car date)
+                                            0)
+                                "~V")
+                   (cdddr date))))))
+   dates))
+
 (begin (newline) (run-s19-tests #t))
 
 


### PR DESCRIPTION
The errata fixed week number displayed by ~V to align ISO definition,
but the reference implementation wasn't updated accordingly.
This patch updates the reference implementation; the behavior matches
'%V' formatter of C99.  Note that it differs from date-week-number in
the way more than the first day of the week offset; the partial week
at the beginning of the year can belong to the last week of the previous
year, or vice versa.

A new file srfi-19-gauche.scm is to load srfi-19.scm into Gauche.
Ideally we want RnRS portable adapter, but that needs more changes.